### PR TITLE
Fixes permissions issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 dokku-letsencrypt is a plugin for [dokku][dokku] that gives the ability to automatically retrieve and install TLS certificates from [letsencrypt.org](https://letsencrypt.org). Contrary to other methods, no temporary disabling of the webserver is required during the ACME challenge procedure (see the 'Design' section for how this is done)!
 
-**Note:** `dokku-letsencrypt` will not autorenew the certificates (but you can run the included certificate renewal procedure in a cronjob).
+**Note:** `dokku-letsencrypt` will not auto-renew the certificates (but you can run the included certificate renewal procedure in a cronjob).
 
 ## Installation
 
 ```sh
 # dokku 0.4+
-$ dokku plugin:install https://github.com/sseemayer/dokku-letsencrypt.git
+$ sudo dokku plugin:install https://github.com/sseemayer/dokku-letsencrypt.git
 ```
 
 ## Commands
 
 ```
 $ dokku help
-    letsencrypt:on <app>                              Enable letsencrypt for app
+    letsencrypt <app>                              Enable or renew letsencrypt certificate for app
 ```
 
 ## Usage

--- a/commands
+++ b/commands
@@ -15,13 +15,13 @@ if [[ $1 == letsencrypt || $1 == letsencrypt:* ]]; then
   verify_app_name "$2"
   APP="$2"
   APP_ROOT="$DOKKU_ROOT/$APP"
+  APP_SSL_ROOT="$DOKKU_ROOT/$APP/tls"
+  LETSENCRYPT_ROOT="$DOKKU_ROOT/.letsencrypt"
 fi
 
 case "$1" in
-  letsencrypt:on)
-
-    dokku_log_info1 "Enabling letsencrypt for $APP..."
-
+  letsencrypt)
+    dokku_log_info1 "Let's Encrypt $APP..."
 
     # TODO dynamically assign ACME port
     ACMEPORT=8888
@@ -37,7 +37,7 @@ case "$1" in
 
   help)
     HELP=$(cat<<EOF
-    letsencrypt:on <app>, Enable letsencrypt for app
+    letsencrypt <app>, Enable or renew letsencrypt for app
 EOF
 )
     if [[ -n $DOKKU_API_VERSION ]]; then
@@ -48,7 +48,7 @@ EOF
     ;;
 
   *)
-    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
     ;;
 
 esac

--- a/functions
+++ b/functions
@@ -13,13 +13,14 @@ reload_nginx () {
   esac
 }
 
-
 letsencrypt_acmeproxy_on () {
   dokku_log_info1 "Enabling ACME proxy for $APP..."
 
   if [[ ! -d "$APP_ROOT/nginx.conf.d" ]]; then
     mkdir "$APP_ROOT/nginx.conf.d"
   fi
+
+  rm -f "$APP_ROOT/nginx.conf.d/letsencrypt.conf"
   cp "$(dirname "$0")/templates/letsencrypt.conf" "$APP_ROOT/nginx.conf.d"
   sed -i "s,{ACMEPORT},$ACMEPORT," "$APP_ROOT/nginx.conf.d/letsencrypt.conf"
 
@@ -32,6 +33,7 @@ letsencrypt_acmeproxy_off() {
   if [[ -f "$APP_ROOT/nginx.conf.d/letsencrypt.conf" ]]; then
     rm "$APP_ROOT/nginx.conf.d/letsencrypt.conf"
   fi
+
   reload_nginx
 }
 
@@ -41,9 +43,28 @@ letsencrypt_update () {
   dokku_log_verbose "done"
 }
 
-letsencrypt_acme () {
+letsencrypt_link () {
+  PRIMARY_DOMAIN=$(dokku url "$APP" | sed -re "s,https?://,,")
+  LIVE="$LETSENCRYPT_ROOT/etc/live/$PRIMARY_DOMAIN"
+  mkdir -p "$APP_SSL_ROOT"
+  ln -nsf "$LIVE/privkey.pem" "$APP_SSL_ROOT/server.key"
+  ln -nsf "$LIVE/fullchain.pem" "$APP_SSL_ROOT/server.crt"
+}
 
-  DOMAINS=$(dokku urls $APP | sed -re "s,https?://,," | uniq)
+letsencrypt_create_root () {
+  # Set up folders
+  if [ ! -d "$LETSENCRYPT_ROOT" ]; then
+    mkdir -p "$LETSENCRYPT_ROOT/etc/"{live,archive}
+    mkdir -p "$LETSENCRYPT_ROOT/var"
+    chgrp dokku "$LETSENCRYPT_ROOT/etc/"{live,archive}
+    chmod 710 "$LETSENCRYPT_ROOT/etc/"{live,archive}
+  fi
+}
+
+letsencrypt_acme () {
+  letsencrypt_create_root
+
+  DOMAINS=$(dokku urls "$APP" | sed -re "s,https?://,," | uniq)
   dokku_log_info1 "Getting letsencrypt certificate for $APP..."
 
   DOMAIN_ARGS=''
@@ -52,29 +73,23 @@ letsencrypt_acme () {
     DOMAIN_ARGS="$DOMAIN_ARGS -d $DOMAIN"
   done
 
-  PRIMARY_DOMAIN=$(dokku url $APP | sed -re "s,https?://,,")
-
-  APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
-
   # run letsencrypt as a docker container using "certonly" mode
   # port 80 of the standalone webserver will be forwarded by the proxy
   docker run -it --rm \
     -p $ACMEPORT:80 \
-    -v "/home/dokku/letsencrypt/etc:/etc/letsencrypt" \
-    -v "/home/dokku/letsencrypt/var:/var/lib/letsencrypt" \
+    -v "$LETSENCRYPT_ROOT/etc:/etc/letsencrypt" \
+    -v "$LETSENCRYPT_ROOT/var:/var/lib/letsencrypt" \
     quay.io/letsencrypt/letsencrypt:latest \
     $DOMAIN_ARGS \
     -a standalone \
     --standalone-supported-challenges http-01 \
     certonly \
-    --renew-by-default
+    --renew-by-default \
+    --agree-tos
 
   # NOTE: add the following to the end to use the letsencrypt staging server:
-  # --server https://acme-staging.api.letsencrypt.org/directory \
+  # --server https://acme-staging.api.letsencrypt.org/directory
 
-  mkdir -p $APP_SSL_PATH
-  ln -nsf "/home/dokku/letsencrypt/etc/live/$PRIMARY_DOMAIN/privkey.pem" "$APP_SSL_PATH/server.key"
-  ln -nsf "/home/dokku/letsencrypt/etc/live/$PRIMARY_DOMAIN/fullchain.pem" "$APP_SSL_PATH/server.crt"
-
-  nginx_build_config $APP
+  letsencrypt_link
+  nginx_build_config "$APP"
 }

--- a/install
+++ b/install
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-
-sudo mkdir -p /home/dokku/letsencrypt/etc/{live,archive}
-sudo mkdir -p /home/dokku/letsencrypt/var
-
-sudo chgrp dokku /home/dokku/letsencrypt/etc/{live,archive}
-sudo chmod 710 /home/dokku/letsencrypt/etc/{live,archive}


### PR DESCRIPTION
So this is kind of large, sorry. Feel free to pick it apart in to your own changes if you'd like. I won't mind :smile: 

The main change here is to fix the permissions of certificates. I'm not sure how it was working for people before (was it?), but the letsencrypt docker container was creating certs with root permissions and dokker couldn't use them. I added another `docker run` command to fix this. Otherwise I had to manually fix the permissions and rerun `nginx:build-config`.

Anyway, I also cleaned some other stuff up, like simplifying the command to `letsencrypt <app>`. I also fixed the README to include `sudo` when installing along with other things.

Cheers!