### PR TITLE
fix multiple domains

### DIFF
--- a/functions
+++ b/functions
@@ -64,7 +64,7 @@ letsencrypt_create_root () {
 letsencrypt_acme () {
   letsencrypt_create_root
 
-  DOMAINS=$(dokku urls "$APP" | sed -re "s,https?://,," | uniq)
+  DOMAINS=$(dokku urls "$APP" | sed -re "s,https?://,," | sed -re "s,\\*\\.,," | sed "s,\\s,\n,g" | uniq | xargs)
   dokku_log_info1 "Getting letsencrypt certificate for $APP..."
 
   DOMAIN_ARGS=''

--- a/functions
+++ b/functions
@@ -64,7 +64,7 @@ letsencrypt_create_root () {
 letsencrypt_acme () {
   letsencrypt_create_root
 
-  DOMAINS=$(dokku urls "$APP" | sed -re "s,https?://,," | sed -re "s,\\*\\.,," | sed "s,\\s,\n,g" | uniq | xargs)
+  DOMAINS=$(dokku urls "$APP" | sed "s,\\s,\n,g" | sed -re "s,https?://,," | sed -re "s,\\*\\.,," | uniq | xargs)
   dokku_log_info1 "Getting letsencrypt certificate for $APP..."
 
   DOMAIN_ARGS=''


### PR DESCRIPTION
Things like `*.example.org` is a valid entry for dokku vhost but is not supported by letsencrypt.